### PR TITLE
 make sure requirements are installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ pushd . > /dev/null
 ### Installing needed packages
 sudo apt-get install advancecomp libimage-exiftool-perl imagemagick \
     optipng libjpeg-progs gifsicle pngnq \
-    tar unzip libpng-dev git
+    tar unzip libpng-dev git make gcc
 
 ### Installing additional software
 mkdir /tmp/imgo-installation/bin -p


### PR DESCRIPTION
We have to use `make` while installing `pngrewrite`,
and `make` also requires `gcc`.

Add `make` and `gcc` packages to requirements list
(since they are absent in some OS like
out-from-the-box Ubuntu 18.04 LTS).