### PR TITLE
Update macOS installation instructions according to new versions of brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,17 @@ Advanced images optimizer
 * Выполняем следующие команды в терминале:
 
 ```shell
-brew install exiftool imagemagick optipng libjpeg gifsicle
+brew install exiftool imagemagick optipng libjpeg gifsicle jonof/kenutils/pngout
 
-formulas='pngrewrite.rb pngout.rb  defluff.rb cryopng.rb imgo.rb'
+formulas='pngrewrite.rb defluff.rb cryopng.rb imgo.rb'
+
+imgodir=$(mktemp -d -t 'imgo.XXX')
 for package in $formulas
 do
-  brew install "https://raw.github.com/imgo/imgo-tools/master/Formula/"$package
+  wget "https://raw.github.com/imgo/imgo-tools/master/Formula/"$package -O $imgodir/$package
+  brew install --HEAD -s $imgodir/$package
 done
+rm -Rf $imgodir
 ```
 You may need to use `sudo` for brew, depending on your setup.
 


### PR DESCRIPTION
It requires https://github.com/imgo/imgo-tools/pull/8 to be merged.

1. I replaced `pngout` formula from imgo-tools with `jonof/kenutils/pngout`
2. I fixed following error:

    ```
    brew install "https://raw.github.com/imgo/imgo-tools/master/Formula/pngrewrite.rb"
    Error: Non-checksummed download of pngrewrite formula file from an arbitrary URL is unsupported! `brew extract` or 
    `brew create` and `brew tap-new` to create a formula file in a tap on GitHub instead.
    ```